### PR TITLE
add option to serve on specific address

### DIFF
--- a/lib/ionic.js
+++ b/lib/ionic.js
@@ -68,7 +68,8 @@ var TASKS = [
       '--port|-p': 'Dev server HTTP port (8100 default)',
       '--livereload-port|-r': 'Live Reload port (35729 default)',
       '--nobrowser|-b': 'Disable launching a browser',
-      '--nolivereload': 'Do not start live reload'
+      '--nolivereload': 'Do not start live reload',
+      '--address': 'Use specific address or return with failure',
     },
     module: './ionic/serve'
   },

--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -523,14 +523,17 @@ IonicTask.prototype.getAddress = function(cb) {
     var ionicConfig = require('./config').load();
 
     var addressConfigKey = (self.isPlatformServe ? 'platformServeAddress' : 'ionicServeAddress');
-    var savedAddress;
+    var tryAddress;
 
     if(self.isAddressCmd) {
       // reset any address configs
       ionicConfig.set('ionicServeAddress', null);
       ionicConfig.set('platformServeAddress', null);
     } else {
-      savedAddress = ionicConfig.get(addressConfigKey);
+      if(!argv.address)
+        tryAddress = ionicConfig.get(addressConfigKey);
+      else
+        tryAddress = argv.address;
     }
 
     if(ifaces){
@@ -547,20 +550,24 @@ IonicTask.prototype.getAddress = function(cb) {
       }
     }
 
-    if(savedAddress) {
-      if(savedAddress == 'localhost') {
-        self.address = savedAddress;
+    if(tryAddress) {
+      if(tryAddress == 'localhost') {
+        self.address = tryAddress;
         cb();
         return;
       }
       for(var x=0; x<addresses.length; x++) {
         // double check if this address is still available
-        if(addresses[x].address == savedAddress) {
+        if(addresses[x].address == tryAddress)
+        {
           self.address = addresses[x].address;
           cb();
           return;
         }
       }
+      //console.log(('\nAddress ' + argv.address + ' not available.').error.bold);
+      self.ionic.fail('Address ' + argv.address + ' not available.');
+      return;
     }
 
     if(addresses.length > 0) {

--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -565,9 +565,10 @@ IonicTask.prototype.getAddress = function(cb) {
           return;
         }
       }
-      //console.log(('\nAddress ' + argv.address + ' not available.').error.bold);
-      self.ionic.fail('Address ' + argv.address + ' not available.');
-      return;
+      if (argv.address) {
+        self.ionic.fail('Address ' + argv.address + ' not available.');
+        return;
+      }
     }
 
     if(addresses.length > 0) {


### PR DESCRIPTION
This adds `ionic serve --address XYZ` to `ionic serve`.

When you `ionic serve`, you potentially get a prompt asking you which address to use, making it unsuitable for scripting (e.g. when inside a vagrant provisionier, or just a convenience script to prepare your coding session).

With `--address`, you now get a specific address, e.g. `ionic serve --address localhost --port 6543`, xor a program failure.
