### PR TITLE
feat(serve): Project Level configurable DocumentRoot

### DIFF
--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -59,7 +59,8 @@ IonicTask.prototype.loadSettings = function(cb) {
   this.printConsoleLogs = argv.consolelogs || argv['console-logs'] || argv.c;
   this.printServerLogs = argv.serverlogs || argv['server-logs'] || argv.s;
   this.isAddressCmd = argv._[0].toLowerCase() == 'address';
-  this.contentSrc = path.join('www', this.ionic.getContentSrc());
+  this.documentRoot = project.get('documentRoot') || 'www';
+  this.contentSrc = path.join(this.documentRoot, this.ionic.getContentSrc());
 
   this.getAddress(cb);
 
@@ -121,7 +122,7 @@ IonicTask.prototype.start = function(ionic) {
     var self = this;
     var app = connect();
 
-    if (!fs.existsSync( path.resolve('www') )) {
+    if (!fs.existsSync( path.resolve(this.documentRoot) )) {
       return ionic.fail('"www" directory cannot be found. Please make sure the working directory is an Ionic project.');
     }
 
@@ -176,7 +177,7 @@ IonicTask.prototype.start = function(ionic) {
     this.devServer = this.host(this.port);
 
     // Serve up the www folder by default
-    var serve = serveStatic('www');
+    var serve = serveStatic(this.documentRoot);
 
     // Create static server
     var server = http.createServer(function(req, res){


### PR DESCRIPTION
When working with Ionic projects I develop everything under a "src" directory instead of "www" and later I created my "gulp dist" task which concats, uglifies, minifies etc and places everything in the "www" folder.

That works perfectly but In order to use ionic serve and avoid executing my "gulp dist" task in the "watch"  I need "ionic serve" to use a different documentRoot, in my case, "src".

Then, my project configuration may change the documentRoot :
```
// ionic.project
{
  "documentRoot" : "src"
}
```