### PR TITLE
Change update to install

### DIFF
--- a/lib/ionic.js
+++ b/lib/ionic.js
@@ -606,7 +606,7 @@ Ionic = {
       process.stdout.write( (' * Locally installed version: ' + settings.version + '\n').yellow );
       process.stdout.write( (' * Latest version: ' + this.npmVersion + '\n').yellow );
       process.stdout.write( (' * https://github.com/driftyco/ionic-cli/blob/master/CHANGELOG.md\n').yellow );
-      process.stdout.write( ' * Run '.yellow + 'npm update -g ionic'.bold + ' to update\n'.yellow );
+      process.stdout.write( ' * Run '.yellow + 'npm install -g ionic'.bold + ' to update\n'.yellow );
       process.stdout.write('------------------------------------\n\n'.red);
       this.npmVersion = null;
     }


### PR DESCRIPTION
`npm update` can be problematic. 
It never works as intended.

Our `npm update` warning should be changed to `npm install` 