### PR TITLE
Fix displaying starter template list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,12 @@ __Local directory starters:__
 
 __Command-line flags/options:__
 
-    --appname, -a  .......  Human readable name for the app
-                            (Use quotes around the name)
-    --id, -i  ............  Package name set in the <widget id> config
-                            ex: com.mycompany.myapp
-    --no-cordova, -w  ....  Do not create an app targeted for Cordova
+    [--appname|-a]  .......  Human readable name for the app
+                             (Use quotes around the name)
+    [--id|-i]  ............  Package name set in the <widget id> config
+                             ex: com.mycompany.myapp
+    [--no-cordova|-w]  ....  Do not create an app targeted for Cordova
+    [--list|-l]  ..........  List starter templates available
 
 
 ## Testing in a Browser

--- a/lib/ionic/templates.js
+++ b/lib/ionic/templates.js
@@ -1,6 +1,5 @@
 var colors = require('colors'),
     path = require('path'),
-    fs = require('fs'),
     _ = require('underscore'),
     Q = require('q'),
     Task = require('./task').Task,
@@ -29,11 +28,9 @@ IonicTask.prototype.fetchStarterTemplates = function() {
   var proxy = process.env.PROXY || null;
   request({ url: downloadUrl, proxy: proxy }, function(err, res, html) {
     if(!err && res && res.statusCode === 200) {
-      // console.log('got html', html)
-      fs.writeFileSync(starterTemplateJsonPath, html, 'utf8');
       var templatesJson = {};
       try {
-        templatesJson = require(starterTemplateJsonPath);
+        templatesJson = JSON.parse(html);
       }catch(ex) {
         console.log('ex', ex)
         q.reject('Error occured in download templates:', ex)


### PR DESCRIPTION
When listing the starter templates with `ionic start --list` it would try to write the response to a file. For Linux and Mac, npm packages are installed under `/usr/lib/node_modules` or `/usr/lib/local/node_modules` which require root privileges to write files; so this would fail and not display the list. This fix just parses the response JSON.
I also updated the documentation.