### PR TITLE
Use console.log instead of deprecated sys.puts

### DIFF
--- a/lib/hooks/after_platform_add/010_install_plugins.js
+++ b/lib/hooks/after_platform_add/010_install_plugins.js
@@ -6,7 +6,6 @@
  */
 var exec = require('child_process').exec;
 var path = require('path');
-var sys = require('sys');
 
 var packageJSON = null;
 
@@ -24,6 +23,6 @@ var cmd = process.platform === 'win32' ? 'cordova.cmd' : 'cordova';
 packageJSON.cordovaPlugins = packageJSON.cordovaPlugins || [];
 packageJSON.cordovaPlugins.forEach(function (plugin) {
   exec('cordova plugin add ' + plugin, function (error, stdout, stderr) {
-    sys.puts(stdout);
+    console.log('%s', stdout);
   });
 });


### PR DESCRIPTION
This prevents unnecessary warning coming from the deprecation of sys/util puts (See nodejs.org/api/util.html#util_util_puts)