### PR TITLE
Allow the creation of the root directory based on an ionic.project file ...

### DIFF
--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -75,6 +75,7 @@ IonicTask.prototype.loadSettings = function(cb) {
   this.printServerLogs = argv.serverlogs || argv['server-logs'] || argv.s;
   this.isAddressCmd = argv._[0].toLowerCase() == 'address';
   this.documentRoot = project.get('documentRoot') || 'www';
+  this.createDocumentRoot = project.get('createDocumentRoot');
   this.contentSrc = path.join(this.documentRoot, this.ionic.getContentSrc());
 
   this.getAddress(cb);
@@ -151,7 +152,11 @@ IonicTask.prototype.start = function(ionic) {
     var childProcess = null;
 
     if (!fs.existsSync( path.resolve(this.documentRoot) )) {
-      return ionic.fail('"www" directory cannot be found. Please make sure the working directory is an Ionic project.');
+      if (this.createDocumentRoot) {
+        fs.mkdirSync(this.documentRoot);
+      } else {
+        return ionic.fail('"' + this.documentRoot + '" directory cannot be found. Please make sure the working directory is an Ionic project.');
+      }
     }
 
     // gulpStartupTasks should be an array of tasks set in the project config


### PR DESCRIPTION
Hello.

I've built with gulp an asset pipeline feature that runs through the ```ionic serve``` command. This pipeline takes the source files from ```my-project/www```, processes them in many different ways, then outputs the result in the ```my-project/www/dist``` dir, which contains the raw js/css that will be served trough ```ionic serve``` and wrapped by cordova in an android/ios project.

Here is my problem: since the content of the ```my-project/www/dist``` always comes from the same source (www), I don't track it with git, just like no one tracks the ```my-project/platforms``` dir. Because of that, after cheking out my project, the ```ionic serve``` throws an error and tells me that the ```www``` dir is not found. So this PR do the following:

- fix the ```ionic serve```error message to output the current dir used as the documentRoot
- allows the creation of the document root, if it doesn't exist, through a ```createDocumentRoot``` option in the ionic.project file

What do you think?
