### PR TITLE
Additional Proxy config parameter to allow connection pooling to be turned off

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ In the `ionic.project` file you can add a property with an array of proxies you 
 
 * `path`: string that will be matched against the beginning of the incoming request URL.
 * `proxyUrl`: a string with the url of where the proxied request should go.
-* `proxyNoAgent` (optional): true/false, if true the connection to the proxy server will not use keep-alives and the default connection pooling of HttpAgent 
+* `proxyNoAgent`: (optional) true/false, if true opts out of connection pooling, see [HttpAgent](http://nodejs.org/api/http.html#http_class_http_agent)
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -226,10 +226,11 @@ __Service Proxies:__
 
 The `serve` command can add some proxies to the http server. These proxies are useful if you are developing in the browser and you need to make calls to an external API. With this feature you can proxy request to the external api through the ionic http server preventing the `No 'Access-Control-Allow-Origin' header is present on the requested resource` error.
 
-In the `ionic.project` file you can add a property with an array of proxies you want to add. The proxies are object with two properties:
+In the `ionic.project` file you can add a property with an array of proxies you want to add. The proxies are object with the following properties:
 
 * `path`: string that will be matched against the beginning of the incoming request URL.
 * `proxyUrl`: a string with the url of where the proxied request should go.
+* `proxyNoAgent` (optional): true/false, if true the connection to the proxy server will not use keep-alives and the default connection pooling of HttpAgent 
 
 ```json
 {

--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -204,7 +204,11 @@ IonicTask.prototype.start = function(ionic) {
       for(var x=0; x<this.proxies.length; x++) {
         var proxy = this.proxies[x];
 
-        app.use(proxy.path, proxyMiddleware(url.parse(proxy.proxyUrl)));
+        var opts = url.parse(proxy.proxyUrl);
+        if(proxy.proxyNoAgent)
+            opts.agent = false;
+
+        app.use(proxy.path, proxyMiddleware(opts));
         console.log('Proxy added:'.green.bold, proxy.path + " => " + url.format(proxy.proxyUrl));
       }
     }


### PR DESCRIPTION
I have been using the proxy feature to avoid CORS issues to our API.  API server is JHipster/Tomcat8.

However we have been running into an annoying problem - after 5 livereloads our application would stop working.  Upon debugging I tracked down the issue to the proxy hanging - it looks like for some reason the proxy is not properly releasing/marking the Http request as complete.  So the default HttpAgent spins up a new socket connection (up to 5) before getting into a blocked state.

This addition allows the proxy request to opt out of the default connection pooling by passing agent=false to the http request - and prevents the deadlock issue.