### PR TITLE
Add browser option to "ionic serve" so that you can specify browser

### DIFF
--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -76,6 +76,8 @@ IonicTask.prototype.loadSettings = function(cb) {
   this.isAddressCmd = argv._[0].toLowerCase() == 'address';
   this.documentRoot = project.get('documentRoot') || 'www';
   this.contentSrc = path.join(this.documentRoot, this.ionic.getContentSrc());
+  this.browser = argv.browser;
+  this.browserOption = argv.browserOption || '';
 
   this.getAddress(cb);
 
@@ -188,7 +190,7 @@ IonicTask.prototype.start = function(ionic) {
             open( self.host(self.port) + IONIC_LAB_URL );
           } else if(self.launchBrowser) {
             var open = require('open');
-            open( self.host(self.port) );
+			open(self.browserOption + ' ' + self.host(self.port), self.browser);
           }
           self.printCommandTips();
         }


### PR DESCRIPTION
Add browser option to "ionic serve" so that you can specify browser.

ex) ionic serve --browser chrome --browserOption "/new-window"
(boot chrome with new window)