### PR TITLE
move rl.close() to occur after child processes are killed

### DIFF
--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -96,8 +96,6 @@ IonicTask.prototype.listenForServerCommands = function listenForServerCommands()
     // console.log('entry', entry)
     var input = (entry + '').trim();
 
-    if (input === 'quit' || input === 'q') rl.close();
-
     if (input === null) return;
     input = (input + '').trim();
 
@@ -128,6 +126,7 @@ IonicTask.prototype.listenForServerCommands = function listenForServerCommands()
     } else if(input == 'quit' || input == 'q') {
       if(self.childProcess) {
         self.childProcess.kill('SIGTERM');
+        rl.close();
       }
       process.exit();
 


### PR DESCRIPTION
This is a fix for the problem outlined in #186.