### PR TITLE
Remove cordova-plugin-crosswalk-webview from plugins on crosswalk revert

### DIFF
--- a/lib/ionic/browser.js
+++ b/lib/ionic/browser.js
@@ -370,6 +370,7 @@ IonicTask.prototype.downloadFiles = function downloadFiles(version) {
 IonicTask.prototype.removeCrosswalk = function removeCrosswalk() {
   shelljs.exec('ionic plugin rm org.apache.cordova.engine.crosswalk')
   shelljs.exec('ionic plugin rm org.crosswalk.engine')
+  shelljs.exec('ionic plugin rm cordova-plugin-crosswalk-webview')
   shelljs.exec('ionic platform rm android')
   shelljs.exec('ionic platform add android')
 }


### PR DESCRIPTION
Removing 'cordova-plugin-crosswalk-webview' from plugins when running 'ionic browser revert android' as plugin is crosswalk resource and so should no longer remain after reverting to Android browser - presence of this plugin caused failure of subsequent attempts to run 'ionic platform add android' after removal of Android platform from project.