### PR TITLE
add rejectUnauthorized option to the proxy configuration to allow untrusted certificates

### DIFF
--- a/lib/ionic/serve.js
+++ b/lib/ionic/serve.js
@@ -326,7 +326,9 @@ IonicTask.prototype.start = function(ionic) {
         var opts = url.parse(proxy.proxyUrl);
         if(proxy.proxyNoAgent)
             opts.agent = false;
-
+        
+        opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
+        
         app.use(proxy.path, proxyMiddleware(opts));
         console.log('Proxy added:'.green.bold, proxy.path + " => " + url.format(proxy.proxyUrl));
       }


### PR DESCRIPTION
See http://forum.ionicframework.com/t/how-to-use-a-proxy-to-https-services/21854/2

This change allows the proxy to accept untrusted certificates, i.e. when proxying to a server on localhost + https