### PR TITLE
Update default plugins for Cordova 5.0.0

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -27,6 +27,7 @@ IonicTask.DEFAULT_APP = {
   "plugins": [
     "cordova-plugin-device",
     "cordova-plugin-console",
+    "cordova-plugin-whitelist",
     "com.ionic.keyboard"
   ],
   "sass": false

--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -25,8 +25,8 @@ IonicTask.WRAPPER_REPO_NAME = 'ionic-app-base';
 
 IonicTask.DEFAULT_APP = {
   "plugins": [
-    "org.apache.cordova.device",
-    "org.apache.cordova.console",
+    "cordova-plugin-device",
+    "cordova-plugin-console",
     "com.ionic.keyboard"
   ],
   "sass": false


### PR DESCRIPTION
Fix these warnings

	running cordova plugin add org.apache.cordova.device
	WARNING: org.apache.cordova.device has been renamed to cordova-plugin-device. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.device` and `cordova plugin add cordova-plugin-device`.
	...
	running cordova plugin add org.apache.cordova.console
	WARNING: org.apache.cordova.console has been renamed to cordova-plugin-console. You may not be getting the latest version! We suggest you `cordova plugin rm org.apache.cordova.console` and `cordova plugin add cordova-plugin-console`.

and add the `cordova-plugin-whitelist` otherwise http requests won't work.