### PR TITLE
Correct ldpi setting for splash screen

### DIFF
--- a/lib/ionic/resources/settings.js
+++ b/lib/ionic/resources/settings.js
@@ -33,13 +33,13 @@ exports.ResPlatforms = {
     },
     splash: {
       images: [
-        { name: 'drawable-land-ldpi-screen.png',    width: 320,   height: 200,   density: 'land-ldpi' },
+        { name: 'drawable-land-ldpi-screen.png',    width: 320,   height: 240,   density: 'land-ldpi' },
         { name: 'drawable-land-mdpi-screen.png',    width: 480,   height: 320,   density: 'land-mdpi' },
         { name: 'drawable-land-hdpi-screen.png',    width: 800,   height: 480,   density: 'land-hdpi' },
         { name: 'drawable-land-xhdpi-screen.png',   width: 1280,  height: 720,   density: 'land-xhdpi' },
         { name: 'drawable-land-xxhdpi-screen.png',  width: 1600,  height: 960,   density: 'land-xxhdpi' },
         { name: 'drawable-land-xxxhdpi-screen.png', width: 1920,  height: 1280,  density: 'land-xxxhdpi' },
-        { name: 'drawable-port-ldpi-screen.png',    width: 200,   height: 320,   density: 'port-ldpi' },
+        { name: 'drawable-port-ldpi-screen.png',    width: 240,   height: 320,   density: 'port-ldpi' },
         { name: 'drawable-port-mdpi-screen.png',    width: 320,   height: 480,   density: 'port-mdpi' },
         { name: 'drawable-port-hdpi-screen.png',    width: 480,   height: 800,   density: 'port-hdpi' },
         { name: 'drawable-port-xhdpi-screen.png',   width: 720,   height: 1280,  density: 'port-xhdpi' },


### PR DESCRIPTION
Dimensions for ldpi splash screen on small screen android are incorrect and cause a distorted image on these devices.

See http://developer.android.com/guide/practices/screens_support.html#screens-table for correct ldpi resolution