### PR TITLE
Fix reference to ```argv```

### DIFF
--- a/lib/ionic/login.js
+++ b/lib/ionic/login.js
@@ -95,6 +95,7 @@ IonicTask.prototype.run = function(ionic, argv, callback) {
 
 IonicTask.prototype.get = function(ionic, callback) {
   this.cookieData = new IonicStore('cookies');
+  var argv = process.argv;
 
   if(ionic.jar) {
     // already in memory


### PR DESCRIPTION

```
Sharing app ... with ....

ReferenceError: argv is not defined
    at Object.IonicTask.get (/usr/local/lib/node_modules/ionic/lib/ionic/login.js:105:16)
    at Object.IonicTask.run (/usr/local/lib/node_modules/ionic/lib/ionic/share.js:57:9)
    at Object.run (/usr/local/lib/node_modules/ionic/lib/cli.js:89:32)
    at Object.<anonymous> (/usr/local/lib/node_modules/ionic/bin/ionic:9:10)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3

argv is not defined (CLI v1.5.2)

Your system information:

Cordova CLI: 4.2.0
Gulp version:  CLI version 3.8.11
Gulp local:   Local version 3.8.11
Ionic CLI Version: 1.5.2
Ionic App Lib Version: 0.2.0
ios-deploy version: 1.5.0 
ios-sim version: 3.1.1 
OS: Mac OS X Yosemite
Node Version: v0.12.0
Xcode version: Xcode 6.3.2 Build version 6D2105 
```