### PR TITLE
Avoid race condition when installing plugins

### DIFF
--- a/lib/hooks/after_platform_add/010_install_plugins.js
+++ b/lib/hooks/after_platform_add/010_install_plugins.js
@@ -22,8 +22,23 @@ var cmd = process.platform === 'win32' ? 'cordova.cmd' : 'cordova';
 // var script = path.resolve(__dirname, '../../node_modules/cordova/bin', cmd);
 
 packageJSON.cordovaPlugins = packageJSON.cordovaPlugins || [];
-packageJSON.cordovaPlugins.forEach(function (plugin) {
-  exec('cordova plugin add ' + plugin, function (error, stdout, stderr) {
-    sys.puts(stdout);
-  });
-});
+
+function installNextPlugin() {
+    var curPlugin = packageJSON.cordovaPlugins.shift();
+    if (curPlugin) {
+        exec('cordova plugin add ' + curPlugin, function(err, stdout, stderr) {
+            sys.puts(stdout);
+            sys.puts(stderr);
+        })
+            .on("exit", function(code) {
+                if (code) {
+                    console.log("'cordova plugin add " + curPlugin + "' failed with code '" + code + "'");
+                    process.exit(code);
+                } else {
+                    installNextPlugin();
+                }
+            });
+    }
+}
+
+installNextPlugin();


### PR DESCRIPTION
When installing multiple plugins asyncronously, a race condition can cause plugins to fail to install, or fail to be registered as installed. As an example, asyncronously installing multiple (5+) plugins often causes `plugins/{platform}.json` to drop plugins as they are all trying to write to it at once.