### PR TITLE
#195 resources phonegap build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,10 @@ If you already have a resources directory, the command above will not over write
 
 When starting a new app and adding a platform `ionic platform add ios` - the default icons and splashscreens will be downloaded and your config.xml will be modified to set up the default resources. This should help you identify your Ionic apps easier as well as help you get the file structure and configuration correct.
 
+## Generating resources configuration for Phonegap Build
+
+Although Phonegap Build uses similar resources during the build, the content of the `config.xml` difers in several ways.
+Generating a Phonegap Build ready configuration can be done by using `ionic resources --phonegap`.
 
 ## Crosswalk for Android
 

--- a/lib/ionic/resources/generate.js
+++ b/lib/ionic/resources/generate.js
@@ -19,7 +19,7 @@ var IonicResources = function() {};
 IonicResources.prototype = new Task();
 
 var settings = resSettings.ResSettings;
-var platformConfigs = resSettings.ResPlatforms;
+var platformConfigs = {}
 var tmpDir = os.tmpdir();
 var configData, buildPlatforms, images, generateQueue, sourceFiles, generatingImages;
 var generateLandscape, generatePortrait, orientation;
@@ -57,6 +57,15 @@ IonicResources.prototype.run = function() {
     })
     return
   }
+
+  if (argv['phonegap']) {
+    settings.phonegap = true;
+    settings.platformElement = 'gap:platform';
+    settings.splashNodeName = 'gap:splash';
+    settings.densityAttribute = 'gap:qualifier';
+  }
+
+  platformConfigs = resSettings.ResPlatforms();
 
   if (!fs.existsSync(settings.resourceDir)) {
     fs.mkdirSync(settings.resourceDir);
@@ -599,6 +608,12 @@ function getConfigData() {
       deferred.reject();
       return;
     }
+    if (settings.phonegap)
+      delete parsedData.widget['platform'];
+    else {
+      delete parsedData.widget['gap:platform'];
+      delete parsedData.widget['gap:splash'];
+    }
     configData = parsedData;
     deferred.resolve(configData);
   }
@@ -636,37 +651,52 @@ function updateConfigData() {
 
   function updateImageNode(image) {
     if (!image) return;
-
-    if (!configData.widget.platform) {
-      configData.widget.platform = [];
+    if (!configData.widget[settings.platformElement]) {
+      configData.widget[settings.platformElement] = [];
     }
 
     var platformConfigData = getPlatformConfigData(image.platform);
 
     if (!platformConfigData) {
-      configData.widget.platform.push({ '$': { name: image.platform } });
+      configData.widget[settings.platformElement].push({ '$': { name: image.platform } });
       platformConfigData = getPlatformConfigData(image.platform);
     }
 
-    if (!platformConfigData[image.nodeName]) {
-      platformConfigData[image.nodeName] = [];
+    var rootNode = settings.phonegap ? configData.widget : platformConfigData;
+
+    if (!rootNode[image.nodeName]) {
+      rootNode[image.nodeName] = [];
     }
 
-    var node = getResourceConfigNode(platformConfigData, image.nodeName, image.src);
+    var node = getResourceConfigNode(rootNode, image.nodeName, image.src);
     if (!node) {
       node = { '$': {} };
-      platformConfigData[image.nodeName].push(node);
+      rootNode[image.nodeName].push(node);
       madeChanges = true;
     }
+
 
     image.nodeAttributes.forEach(function(nodeAttribute) {
       node.$[nodeAttribute] = image[nodeAttribute];
     });
+    if (settings.phonegap) {
+      node.$['gap:platform'] = image.platform;
+    }
+  }
+
+  function getDefaultIconNode() {
+    if (configData.widget.icon) {
+      return _.find(configData.widget.icon, function(d) {
+        return d && d.$ && !d.$.width && !d.$.height && !d.$[settings.densityAttribute] && !d.$[settings.platformElement];
+      });
+    }
   }
 
   function buildDefaultIconNode() {
     var currentSize = 0;
     var defaultIcon;
+
+    var defaultIconNode = getDefaultIconNode();
 
     images.forEach(function(image) {
       if (image && image.resType == 'icon' && image.width > currentSize && image.width <= settings.defaultMaxIconSize) {
@@ -676,7 +706,16 @@ function updateConfigData() {
     });
 
     if (defaultIcon) {
-      configData.widget.icon = [{ '$': { src: defaultIcon.src } }];
+      if (settings.phonegap) {
+        var defaultIconNode = getDefaultIconNode();
+        if (defaultIconNode) {
+          defaultIcon.src = defaultIcon.src;
+        } else {
+          configData.widget.icon.push({ '$': { src: defaultIcon.src }});
+        }
+      } else {
+        configData.widget.icon = [{ '$': { src: defaultIcon.src }}];
+      }
       madeChanges = true;
     }
   }
@@ -725,8 +764,8 @@ function getOrientationConfigData(platform) {
 }
 
 function getPlatformConfigData(platform) {
-  if (configData.widget && configData.widget.platform) {
-    return _.find(configData.widget.platform, function(d) {
+  if (configData.widget && configData.widget[settings.platformElement]) {
+    return _.find(configData.widget[settings.platformElement], function(d) {
       return d && d.$ && d.$.name == platform;
     });
   }

--- a/lib/ionic/resources/settings.js
+++ b/lib/ionic/resources/settings.js
@@ -12,101 +12,112 @@ exports.ResSettings = {
   configFile: 'config.xml',
   generateThrottle: 4,
   defaultMaxIconSize: 96,
-  cacheImages: true
+  cacheImages: true,
+  splashNodeName: 'splash',
+  densityAttribute: 'density',
+  platformElement: 'platform'
 };
 
+exports.getNode = function(name, width, height, density) {
+  var node =  { name: name, width: width, height: height, density: density };
+  if (density) {
+    node[this.ResSettings.densityAttribute] = density;
+  }
+  return node;
+};
 
-exports.ResPlatforms = {
-
-  android: {
-    icon: {
-      images: [
-        { name: 'drawable-ldpi-icon.png',    width: 36,   height: 36,   density: "ldpi" },
-        { name: 'drawable-mdpi-icon.png',    width: 48,   height: 48,   density: "mdpi" },
-        { name: 'drawable-hdpi-icon.png',    width: 72,   height: 72,   density: "hdpi" },
-        { name: 'drawable-xhdpi-icon.png',   width: 96,   height: 96,   density: "xhdpi" },
-        { name: 'drawable-xxhdpi-icon.png',  width: 144,  height: 144,  density: "xxhdpi" },
-        { name: 'drawable-xxxhdpi-icon.png', width: 192,  height: 192,  density: "xxxhdpi" }
-      ],
-      nodeName: 'icon',
-      nodeAttributes: ['src', 'density']
+exports.ResPlatforms = function() {
+  return {
+    android: {
+      icon: {
+        images: [
+          this.getNode('drawable-ldpi-icon.png', 36, 36, "ldpi"),
+          this.getNode('drawable-mdpi-icon.png', 48, 48, "ldpi"),
+          this.getNode('drawable-hdpi-icon.png', 72, 72, "ldpi"),
+          this.getNode('drawable-xhdpi-icon.png', 96, 96, "ldpi"),
+          this.getNode('drawable-xxhdpi-icon.png', 144, 144, "ldpi"),
+          this.getNode('drawable-xxxhdpi-icon.png', 192, 36, "ldpi")
+        ],
+        nodeName: 'icon',
+        nodeAttributes: ['src', this.ResSettings.densityAttribute]
+      },
+      splash: {
+        images: [
+          this.getNode('drawable-land-ldpi-screen.png', 320, 240, "land-ldpi"),
+          this.getNode('drawable-land-mdpi-screen.png', 480, 320, "land-mdpi"),
+          this.getNode('drawable-land-hdpi-screen.png', 800, 480, "land-hdpi"),
+          this.getNode('drawable-land-xhdpi-screen.png', 1280, 720, "land-xhdpi"),
+          this.getNode('drawable-land-xxhdpi-screen.png', 1600, 960, "land-xxhdpi"),
+          this.getNode('drawable-land-xxxhdpi-screen.png', 1920, 1280, "land-xxxhdpi"),
+          this.getNode('drawable-port-ldpi-screen.png', 240, 320, "port-ldpi"),
+          this.getNode('drawable-port-mdpi-screen.png', 320, 480, "port-mdpi"),
+          this.getNode('drawable-port-hdpi-screen.png', 480, 800, "port-hdpi"),
+          this.getNode('drawable-port-xhdpi-screen.png', 720, 1280, "port-xhdpi"),
+          this.getNode('drawable-port-xxhdpi-screen.png', 960, 1600, "port-xxhdpi"),
+          this.getNode('drawable-port-xxxhdpi-screen.png', 1280, 1920, "port-xxxhdpi")
+        ],
+        nodeName: this.ResSettings.splashNodeName,
+        nodeAttributes: ['src', this.ResSettings.densityAttribute]
+      }
     },
-    splash: {
-      images: [
-        { name: 'drawable-land-ldpi-screen.png',    width: 320,   height: 240,   density: 'land-ldpi' },
-        { name: 'drawable-land-mdpi-screen.png',    width: 480,   height: 320,   density: 'land-mdpi' },
-        { name: 'drawable-land-hdpi-screen.png',    width: 800,   height: 480,   density: 'land-hdpi' },
-        { name: 'drawable-land-xhdpi-screen.png',   width: 1280,  height: 720,   density: 'land-xhdpi' },
-        { name: 'drawable-land-xxhdpi-screen.png',  width: 1600,  height: 960,   density: 'land-xxhdpi' },
-        { name: 'drawable-land-xxxhdpi-screen.png', width: 1920,  height: 1280,  density: 'land-xxxhdpi' },
-        { name: 'drawable-port-ldpi-screen.png',    width: 240,   height: 320,   density: 'port-ldpi' },
-        { name: 'drawable-port-mdpi-screen.png',    width: 320,   height: 480,   density: 'port-mdpi' },
-        { name: 'drawable-port-hdpi-screen.png',    width: 480,   height: 800,   density: 'port-hdpi' },
-        { name: 'drawable-port-xhdpi-screen.png',   width: 720,   height: 1280,  density: 'port-xhdpi' },
-        { name: 'drawable-port-xxhdpi-screen.png',  width: 960,   height: 1600,  density: 'port-xxhdpi' },
-        { name: 'drawable-port-xxxhdpi-screen.png', width: 1280,  height: 1920,  density: 'port-xxxhdpi' }
-      ],
-      nodeName: 'splash',
-      nodeAttributes: ['src', 'density']
-    }
-  },
 
-  ios: {
-    icon: {
-      images: [
-        { name: 'icon.png',             width: 57,    height: 57 },
-        { name: 'icon@2x.png',          width: 114,   height: 114 },
-        { name: 'icon-40.png',          width: 40,    height: 40 },
-        { name: 'icon-40@2x.png',       width: 80,    height: 80 },
-        { name: 'icon-50.png',          width: 50,    height: 50 },
-        { name: 'icon-50@2x.png',       width: 100,   height: 100 },
-        { name: 'icon-60.png',          width: 60,    height: 60 },
-        { name: 'icon-60@2x.png',       width: 120,   height: 120 },
-        { name: 'icon-60@3x.png',       width: 180,   height: 180 },
-        { name: 'icon-72.png',          width: 72,    height: 72 },
-        { name: 'icon-72@2x.png',       width: 144,   height: 144 },
-        { name: 'icon-76.png',          width: 76,    height: 76 },
-        { name: 'icon-76@2x.png',       width: 152,   height: 152 },
-        { name: 'icon-small.png',       width: 29,    height: 29 },
-        { name: 'icon-small@2x.png',    width: 58,    height: 58 },
-        { name: 'icon-small@3x.png',    width: 87,    height: 87 }
-      ],
-      nodeName: 'icon',
-      nodeAttributes: ['src', 'width', 'height']
+    ios: {
+      icon: {
+        images: [
+          this.getNode('icon.png', 57, 57),
+          this.getNode('icon@2x.png', 114, 114),
+          this.getNode('icon-40.png', 40, 40),
+          this.getNode('icon-40@2x.png', 80, 80),
+          this.getNode('icon-50.png', 50, 50),
+          this.getNode('icon-50@2x.png', 100, 100),
+          this.getNode('icon-60.png', 60, 60),
+          this.getNode('icon-60@2x.png', 120, 120),
+          this.getNode('icon-60@3x.png', 180, 180),
+          this.getNode('icon-72.png', 72, 72),
+          this.getNode('icon-72@2x.png', 144, 144),
+          this.getNode('icon-76.png', 76, 76),
+          this.getNode('icon-76@2x.png', 152, 152),
+          this.getNode('icon-small.png', 29, 29),
+          this.getNode('icon-small@2x.png', 58, 58),
+          this.getNode('icon-small@3x.png', 87, 87)
+        ],
+        nodeName: 'icon',
+        nodeAttributes: ['src', 'width', 'height']
+      },
+      splash: {
+        images: [
+          this.getNode('Default-568h@2x~iphone.png', 640, 1136),
+          this.getNode('Default-667h.png', 750, 1334),
+          this.getNode('Default-736h.png', 1242, 2208),
+          this.getNode('Default-Landscape-736h.png', 2208, 1242),
+          this.getNode('Default-Landscape@2x~ipad.png', 2048, 1536),
+          this.getNode('Default-Landscape~ipad.png', 1024, 768),
+          this.getNode('Default-Portrait@2x~ipad.png', 1536, 2048),
+          this.getNode('Default-Portrait~ipad.png', 768, 1024),
+          this.getNode('Default@2x~iphone.png', 640, 960),
+          this.getNode('Default~iphone.png', 320, 480)
+        ],
+        nodeName: this.ResSettings.splashNodeName,
+        nodeAttributes: ['src', 'width', 'height']
+      }
     },
-    splash: {
-      images: [
-        { name: 'Default-568h@2x~iphone.png',     width: 640,   height: 1136 },
-        { name: 'Default-667h.png',               width: 750,   height: 1334 },
-        { name: 'Default-736h.png',               width: 1242,  height: 2208 },
-        { name: 'Default-Landscape-736h.png',     width: 2208,  height: 1242 },
-        { name: 'Default-Landscape@2x~ipad.png',  width: 2048,  height: 1536 },
-        { name: 'Default-Landscape~ipad.png',     width: 1024,  height: 768 },
-        { name: 'Default-Portrait@2x~ipad.png',   width: 1536,  height: 2048 },
-        { name: 'Default-Portrait~ipad.png',      width: 768,   height: 1024 },
-        { name: 'Default@2x~iphone.png',          width: 640,   height: 960 },
-        { name: 'Default~iphone.png',             width: 320,   height: 480 }
-      ],
-      nodeName: 'splash',
-      nodeAttributes: ['src', 'width', 'height']
-    }
-  },
 
-  wp8: {
-    icon: {
-      images: [
-        { name: 'ApplicationIcon.png',  width: 99,   height: 99 },
-        { name: 'Background.png',       width: 159,  height: 159 }
-      ],
-      nodeName: 'icon',
-      nodeAttributes: ['src', 'width', 'height']
-    },
-    splash: {
-      images: [
-        { name: 'SplashScreenImage.png',  width: 768,   height: 1280 }
-      ],
-      nodeName: 'splash',
-      nodeAttributes: ['src', 'width', 'height']
+    wp8: {
+      icon: {
+        images: [
+          this.getNode('ApplicationIcon.png', 99, 99),
+          this.getNode('Background.png', 159, 159)
+        ],
+        nodeName: 'icon',
+        nodeAttributes: ['src', 'width', 'height']
+      },
+      splash: {
+        images: [
+          this.getNode('SplashScreenImage.png', 768, 1280)
+        ],
+        nodeName: this.ResSettings.splashNodeName,
+        nodeAttributes: ['src', 'width', 'height']
+      }
     }
   }
 


### PR DESCRIPTION
Reference to https://github.com/driftyco/ionic-cli/issues/195

As I needed to use `ionic resources` on a project using Phonegap Build, I added a `--phonegap` flag to the command in order for it to generate a phonegap build ready `config.xml`.

Might be useful to others as I've seen the command is being used as a standalone tool.

Could not locate any unit or e2e test about this command but if there are some, don't hesitate to ask for some :) I've tested the feature by hand in the following scenarios, with success, but I may have missed some :

- Empty config.xml (both with or without the flag)
- Applying the same command several times without any change (both with or without the flag)
- Alternating running the command with and without the flag
- Running the command with existing nodes in config.xml