### PR TITLE
Specify a different address for devices to connect to for ionic run --livereload

### DIFF
--- a/lib/ionic/cordova.js
+++ b/lib/ionic/cordova.js
@@ -261,6 +261,9 @@ IonicTask.prototype.setupLiveReload = function(argv) {
   }
 
   var externalAddress = argv['external-address'] || argv.e;
+  if (externalAddress) {
+    console.log('Connecting to ' + externalAddress + ' from device');
+  }
 
   return promise
   .then(function() {

--- a/lib/ionic/cordova.js
+++ b/lib/ionic/cordova.js
@@ -136,12 +136,14 @@ IonicTask.prototype.runCordova = function(cmdName, argv) {
   var cleanArgs = [];
   var port = argv.port || argv.p || '';
   var liveReloadPort = argv.livereloadport || argv['livereload-port'] || argv.r || '';
-  var ignoreCmds = '--livereload -l --consolelogs -c --serverlogs -s --port -p --livereload-port -i -r'.split(' ');
+  var externalAddress = argv.externaladdress || argv['external-address'] || argv.e || '';
+  var ignoreCmds = '--livereload -l --consolelogs -c --serverlogs -s --port -p --livereload-port -i -r --external-address -e'.split(' ');
   var isValdCmd;
   for(x=0; x<cmdArgs.length; x++) {
     cmdArg = cmdArgs[x];
     if(port && cmdArg == port) continue;
     if(liveReloadPort && cmdArg == liveReloadPort) continue;
+    if(externalAddress && cmdArg == externalAddress) continue;
     isValdCmd = true;
     for(y=0; y<ignoreCmds.length; y++) {
       if(cmdArg == ignoreCmds[y]) {
@@ -258,6 +260,8 @@ IonicTask.prototype.setupLiveReload = function(argv) {
     promise = Serve.getAddress(options);
   }
 
+  var externalAddress = argv['external-address'] || argv.e;
+
   return promise
   .then(function() {
     options.devServer = Serve.host(options.address, options.port);
@@ -269,8 +273,9 @@ IonicTask.prototype.setupLiveReload = function(argv) {
     }
   })
   .then(function() {
+    var devServerAddress = externalAddress || options.address;
     ConfigXml.setConfigXml( process.cwd(), {
-      devServer: Serve.host(options.address, options.port)
+      devServer: Serve.host(devServerAddress, options.port)
     }).then(function(){
       d.resolve();
     });

--- a/lib/tasks/cliTasks.js
+++ b/lib/tasks/cliTasks.js
@@ -10,6 +10,7 @@ var cordovaRunEmulateOptions = {
   '--livereload|-l': 'Live reload app dev files from the device' + ' (beta)'.yellow,
   '--port|-p': 'Dev server HTTP port (8100 default, livereload req.)',
   '--livereload-port|-r': 'Live Reload port (35729 default, livereload req.)',
+  '--external-address|-e': 'Cordova app/emulator will connect to this address',
   '--consolelogs|-c': {
     title: 'Print app console logs to Ionic CLI (livereload req.)',
     boolean: true


### PR DESCRIPTION
I'm running ionic-cli from a Docker container that has a different IP than the host machine's IP on the LAN. `ionic run --livereload` by default builds an app that attempts to connect to the IP it serves on (the Docker container's IP in this case, which does not exist on the LAN).

This PR adds a `--external-address` parameter where users can specify a different address for the device to connect to.

I pushed a version to https://www.npmjs.com/package/ionic-run-external-address to use for my app in the mean time. Feel free to give it a spin if you need something like this now.

Let me know if there's anything that needs to be changed.

Related issue: #557