### PR TITLE
Require `util` module instead of the deprecated `sys` module in `010_install_plugins.js`.

### DIFF
--- a/lib/hooks/after_platform_add/010_install_plugins.js
+++ b/lib/hooks/after_platform_add/010_install_plugins.js
@@ -6,7 +6,7 @@
  */
 var exec = require('child_process').exec;
 var path = require('path');
-var sys = require('sys');
+var util = require('util');
 
 var packageJSON = null;
 
@@ -24,6 +24,6 @@ var cmd = process.platform === 'win32' ? 'cordova.cmd' : 'cordova';
 packageJSON.cordovaPlugins = packageJSON.cordovaPlugins || [];
 packageJSON.cordovaPlugins.forEach(function (plugin) {
   exec('cordova plugin add ' + plugin, function (error, stdout, stderr) {
-    sys.puts(stdout);
+    util.puts(stdout);
   });
 });


### PR DESCRIPTION
`sys` module was deprecated long ago.

There is an ongoing discussion on removing `sys` module completely in the next major version: https://github.com/nodejs/node/pull/2405.