### PR TITLE
change the error message when it fails to ionic generate

### DIFF
--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -7,6 +7,20 @@ var fs = require('fs'),
     logging = ionicAppLib.logging,
     Info = ionicAppLib.info;
 
+var printHelpMessage = function() {
+  logging.logger.info('Get started using generators right now!')
+  logging.logger.info('Generators help you set up code quickly to get running.');
+  logging.logger.info('List all the generators by passing the --list option: "ionic g --list"');
+  logging.logger.info('Or simply type "ionic g page MyPage" to generate a page!');
+};
+
+var printErrorMessage = function(ex) {
+  logging.logger.info('There was an error generating your item.'.red);
+  logging.logger.info('run ionic g help for available commands.'.red);
+
+  Utils.fail(ex);
+};
+
 var IonicTask = function() {};
 
 IonicTask.prototype = new Task();
@@ -30,10 +44,7 @@ IonicTask.prototype.run = function(ionic, argv) {
     }
 
     if (generator == 'help') {
-      logging.logger.info('Get started using generators right now!')
-      logging.logger.info('Generators help you set up code quickly to get running.');
-      logging.logger.info('List all the generators by passing the --list option: "ionic g --list"');
-      logging.logger.info('Or simply type "ionic g page MyPage" to generate a page!');
+      printHelpMessage();
       return;
     }
 
@@ -65,13 +76,10 @@ IonicTask.prototype.run = function(ionic, argv) {
       if (ex.message.indexOf('no generator available') != -1) {
         return console.log('✗ '.red + ex.message.red);
       }
-      return Utils.fail('You do not appear to have a compatible version of Ionic v2 installed.\n' +
-      'Ionic Framework v2 version 2.0.0-alpha.31 or later is required to use the generators.\n' +
-      'Please run: "npm install ionic-framework"');
+      return printErrorMessage(ex);
     }
-
   } catch (ex) {
-    Utils.fail('There was an error generating your item:', ex);
+    return printErrorMessage(ex);
   }
 }
 


### PR DESCRIPTION
trying to make the error message easier for troubleshooting regarding the issue https://github.com/driftyco/ionic-cli/issues/698

the error message is updated to:

    $ ionic g -l
    There was an error generating your item.
    run ionic g help for available commands.

    TypeError: Cannot read property 'replace' of undefined
        at Object.fileName (/Users/eddielau/projects/github_repos/ionic2/dist/tooling/generate.js:210:14)
        at Object.cssClassName (/Users/eddielau/projects/github_repos/ionic2/dist/tooling/generate.js:214:19)
        at Object.generate (/Users/eddielau/projects/github_repos/ionic2/dist/tooling/generate.js:45:28)
        at Object.IonicTask.run (/usr/local/lib/node_modules/ionic/lib/ionic/generate.js:73:28)
        at Promise.apply (/usr/local/lib/node_modules/ionic/node_modules/q/q.js:1078:26)
        at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/ionic/node_modules/q/q.js:741:41)
        at /usr/local/lib/node_modules/ionic/node_modules/q/q.js:1304:14
        at flush (/usr/local/lib/node_modules/ionic/node_modules/q/q.js:108:17)
        at doNTCallback0 (node.js:417:9)
        at process._tickCallback (node.js:346:13)


    Cannot read property 'replace' of undefined (CLI v2.0.0-beta.12)

    Your system information:

    Cordova CLI: 5.4.1
    Gulp version:  CLI version 3.8.11
    Gulp local:   Local version 3.9.0
    Ionic Version: 2.0.0-alpha.44
    Ionic CLI Version: 2.0.0-beta.12
    Ionic App Lib Version: 2.0.0-beta.6
    ios-deploy version: 1.5.0
    ios-sim version: 3.1.1
    OS: Mac OS X El Capitan
    Node Version: v4.2.1
    Xcode version: Xcode 7.2 Build version 7C68