### PR TITLE
Update bower error msg

### DIFF
--- a/lib/ionic/add.js
+++ b/lib/ionic/add.js
@@ -20,7 +20,8 @@ IonicTask.prototype.installBowerComponent = function installBowerComponent(compo
 
   if (result.code != 0) {
     //Error happened, report it.
-    var errorMessage = 'Failed to find the bower component "'.error.bold + componentName.verbose + '"'.error.bold + '.\nAre you sure it exists?'.error.bold;
+    var errorMessage = 'Bower error, check that "'.error.bold + componentName.verbose + '"'.error.bold + ' exists,'.error.bold + 
+                       '\nor try running "'.error.bold + bowerInstallCommand.verbose + '" for more info.'.error.bold;
     this.ionic.fail(errorMessage, 'add');
   } else {
     var message = 'Bower component installed - ' + componentName;


### PR DESCRIPTION
Stating that the package couldn't be found on any bower error is confusing when things like version conflicts occur (This happens a _lot_ with bower, especially when adding the `ionic-platform-web-client`).

Ideally, we should make bower a dependency of the cli, and not be installing via `exec('some-command-here')`, but this should at least provide a bit better info.