### PR TITLE
Support for Typescript Generators

### DIFF
--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -6,6 +6,7 @@ var fs = require('fs'),
     Utils = ionicAppLib.utils,
     logging = ionicAppLib.logging,
     Info = ionicAppLib.info;
+    Project =  ionicAppLib.project;
 
 var IonicTask = function() {};
 
@@ -21,10 +22,17 @@ IonicTask.prototype.run = function(ionic, argv) {
     if (!argv.v2) {
       return Utils.fail('Generators are only available for Ionic 2 projects');
     }
+	
+	var project;
+	try {
+		var project = Project.load(process.cwd());
+	} catch (err){
+		return Utils.fail(err);
+	}
 
     var generator = argv._[1];
     var name = argv._[2] //TODO support multiple names
-    var isTS = argv.ts;
+    var isTS = project.typescript || argv.ts;
 
     var ionicModule = loadToolingModule();
 

--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -25,7 +25,7 @@ IonicTask.prototype.run = function(ionic, argv) {
   
     var project;
     try {
-      var project = Project.load(process.cwd());
+      project = Project.load(process.cwd());
     } catch (err){
       return Utils.fail(err);
     }

--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -24,7 +24,7 @@ IonicTask.prototype.run = function(ionic, argv) {
 
     var generator = argv._[1];
     var name = argv._[2] //TODO support multiple names
-	var isTS = argv.ts;
+    var isTS = argv.ts;
 
     var ionicModule = loadToolingModule();
 

--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -24,7 +24,7 @@ IonicTask.prototype.run = function(ionic, argv) {
 
     var generator = argv._[1];
     var name = argv._[2] //TODO support multiple names
-	var isTS = argv._[3] != null 
+	var isTS = argv.ts;
 
     var ionicModule = loadToolingModule();
 

--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -24,6 +24,7 @@ IonicTask.prototype.run = function(ionic, argv) {
 
     var generator = argv._[1];
     var name = argv._[2] //TODO support multiple names
+	var isTS = argv._[3] != null 
 
     var ionicModule = loadToolingModule();
 
@@ -34,7 +35,7 @@ IonicTask.prototype.run = function(ionic, argv) {
 
     var promise;
     try {
-      promise = ionicModule.generate({appDirectory: process.cwd(), generator: generator, name: name});
+      promise = ionicModule.generate({appDirectory: process.cwd(), generator: generator, name: name, isTS: isTS});
     } catch (err) {
       if (err.message.indexOf('no generator available') != -1) {
         console.log('✗ '.red + err.message.red);

--- a/lib/ionic/generate.js
+++ b/lib/ionic/generate.js
@@ -22,13 +22,13 @@ IonicTask.prototype.run = function(ionic, argv) {
     if (!argv.v2) {
       return Utils.fail('Generators are only available for Ionic 2 projects');
     }
-	
-	var project;
-	try {
-		var project = Project.load(process.cwd());
-	} catch (err){
-		return Utils.fail(err);
-	}
+  
+    var project;
+    try {
+      var project = Project.load(process.cwd());
+    } catch (err){
+      return Utils.fail(err);
+    }
 
     var generator = argv._[1];
     var name = argv._[2] //TODO support multiple names

--- a/lib/tasks/cliTasks.js
+++ b/lib/tasks/cliTasks.js
@@ -513,6 +513,10 @@ var TASKS = [
       '--list': {
         title: 'List available generators',
         boolean: true
+      },
+	  '--typescript|--ts': {
+        boolean: true,
+        title: '(with --v2 only) Use TypeScript in generation'
       }
     },
    }

--- a/lib/tasks/cliTasks.js
+++ b/lib/tasks/cliTasks.js
@@ -514,7 +514,7 @@ var TASKS = [
         title: 'List available generators',
         boolean: true
       },
-	  '--typescript|--ts': {
+      '--typescript|--ts': {
         boolean: true,
         title: '(with --v2 only) Use TypeScript in generation'
       }


### PR DESCRIPTION
This adds support to pass a --ts argument to `ionic g` to generate typescript code instead of ES6.

Supported by driftyco/ionic#6008