### PR TITLE
fix(#594): propagate Cordova error code

### DIFF
--- a/lib/ionic/cordova.js
+++ b/lib/ionic/cordova.js
@@ -72,8 +72,12 @@ IonicTask.prototype.run = function(ionic, argv) {
       return self.runCordova(cmdName, argv);
     })
     .then(function(runCode) {
-      //We dont want to do anything if the cordova command failed
-      if(runCode !== 0 || argv.nosave) {
+      // If the cordova command failed, abort immediately and propagate the error code
+      if (runCode !== 0) {
+        console.log(('Cordova command failed with error code ' + runCode + ', aborting!').red.bold);
+        process.exit(runCode);
+      }
+      if (argv.nosave) {
         return
       }
       var argumentName = argv._[2];


### PR DESCRIPTION
Fix #594 

Hello, I believe that aborting and exiting right away in case of Cordova command failure is a sensible way to do, but I don't know the whole ionic codebase, so I'm open for suggestions from the ionic team.

FYI when I `throw` instead, the ionic process still exit with code `0`, that's why I used `process.exit()` directly.

To reproduce the bug clone https://github.com/jakub-g/ionic-cli-bug-594 and follow README

To reproduce the fix, `npm uninstall -g ionic`, clone this branch, `npm link` and later follow README as above