### PR TITLE
Add summary and options in settings of login

### DIFF
--- a/lib/ionic/login.js
+++ b/lib/ionic/login.js
@@ -11,6 +11,11 @@ var appLibSettings = IonicAppLib.settings;
 var settings =  {
   title: 'login',
   name: 'login',
+  summary: 'Login to your Ionic account',
+  options: {
+    '--email|-e': 'Ionic account email',
+    '--password|-p': 'Ionic account password'
+  },
   isProjectTask: false
 };
 


### PR DESCRIPTION
Currently when we used `ionic help`, the login command is not listed.  (see this thread : https://forum.ionicframework.com/t/getting-a-session-expired-401-error-in-ionic-cli-for-ionic-upload-command/61749/4 )

This PR adds 'summary' and 'options' for the login command.

