### PR TITLE
allow period to be used for cwd when the app name is provided after it.

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -62,7 +62,7 @@ function run(ionic, argv) {
     return appLibUtils.fail('Invalid command', 'start');
   }
 
-  if (argv._[1] === '.') {
+  if (argv._[1] === '.' && (argv._[2] === 'undefined' || argv._[2].toString().length === 0)) {
     return log.error('Please name your Ionic project something meaningful other than \'.\''.red);
   }
 


### PR DESCRIPTION
I haven't been able to test this, I can't figure out how.  If you can provide me with a little insight how to test this I'd be glad to.

Preliminarily though, this should resolve the issue when trying to create an ionic app in the current directory.  

When running the following command:

```
ionic start --app-name "myApp" --id "com.myCo.myApp" --sass . blank
```
Due to the way the arguments are currently parsed, the argument parser doesn't check to see if there's something to the right of `.`, which there is if you're using the current directory using a template.

The directions for `ionic start` say:
```
start [options] <PATH> [template] 
```

since `.` is a valid identifier for path, the above *should* work.

This PR addresses that.
