### PR TITLE
Fixed regex that gets class attribute in hook add platform class. Failed with pipe in class

### DIFF
--- a/lib/hooks/after_prepare/010_add_platform_class.js
+++ b/lib/hooks/after_prepare/010_add_platform_class.js
@@ -72,7 +72,7 @@ function findClassAttr(bodyTag) {
 
   // get the body tag's class attribute
   try {
-    return bodyTag.match(/ class=["|'](.*?)["|']/gi)[0];
+    return bodyTag.match(/ class=['"](.*?)['"]/gi)[0];
   } catch (e) {
     console.log('failure in findClassAttr');
   }


### PR DESCRIPTION
In the hook after prepare, `010_add_platform_class.js`, the [regex to get class attribute will fail](https://regex101.com/r/amKhLj/2) if there is a pipe (|) character. E.g adding an angular variable with a filter into class attribute.
`<body ng-app="myApp" class="some-class {{scopeVariable | filterName}}" anotherAttr="">`

Proposed [new regex doesn't fail](https://regex101.com/r/amKhLj/1).

But it [still will fail](https://regex101.com/r/4oEvpR/2) if a parameter with quotes is added to angular filter:
`  <body ng-app="myApp" class="some-class {{scopeVariable | filterName:'parameter'}}" anotherAttr="">`



