### PR TITLE
Update error message in ionic share task

### DIFF
--- a/lib/ionic/share.js
+++ b/lib/ionic/share.js
@@ -24,7 +24,7 @@ function run(ionic, argv) {
   var project;
 
   if (argv._.length < 2) {
-    return appLibUtils.fail('Invalid command', 'share');
+    return appLibUtils.fail('Invalid arguments. Usage: ionic share <email>', 'share');
   }
 
   try {


### PR DESCRIPTION
Update error message in ionic share task to be more descriptive when the user doesn't enter an email.