### PR TITLE
Increase amount of data allowed on stdout's Cordova child process

### DIFF
--- a/lib/utils/cordova.js
+++ b/lib/utils/cordova.js
@@ -72,7 +72,7 @@ function execCordovaCommand(optionList, isLiveReload, serveOptions) {
   isLiveReload = !!isLiveReload;
 
   log.debug('Executing cordova cli: ' + optionList.join(' '));
-  var cordovaProcess = childProcess.exec('cordova ' + optionList.join(' '));
+  var cordovaProcess = childProcess.exec('cordova ' + optionList.join(' '), { maxBuffer: 10000 * 1024  });
 
   cordovaProcess.stdout.on('data', function(data) {
     log.info(data.toString());


### PR DESCRIPTION
When running for iOS device using

`ionic run ios --device`

the Cordova child process is spawned from Ionic with a default `maxBuffer = 200*1024` bytes. This is not enough to support all child process logs and that process is killed.

See Node.js documentation for `child_process.exec`:

https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback

This problem causes some issues reported by other users:

https://forum.ionicframework.com/t/ionic-run-ios-device-does-not-work-and-stops-at-the-same-place-everytime/68772

For very simple projects the problem is not detected, but in projects with many Cordova plugins the Xcode building (launched from Cordova CLI) has a very long output log that is stored in the buffer of the `child_process.exec` function from Node.

This PR increases that buffer for fixing the issue.

Tested with the following `ionic info`:

Cordova CLI: 6.4.0 
Ionic CLI Version: 2.1.12
Ionic App Lib Version: 2.1.7
ios-deploy version: 1.9.0 
ios-sim version: 5.0.11 
OS: macOS Sierra
Node Version: v7.1.0
Xcode version: Xcode 8.1 Build version 8B62