### PR TITLE
Fix `ionic lib update` "invalid version: undefined" error

### DIFF
--- a/lib/ionic/lib.js
+++ b/lib/ionic/lib.js
@@ -98,7 +98,7 @@ function printLibVersions(data) {
 }
 
 
-function getVersionData(data, version) {
+function getVersionData(version, data) {
   var q = Q.defer();
 
   var url = 'http://code.ionicframework.com';


### PR DESCRIPTION
This switches the arguments in `getVersionData` and stops the **`Invalid version: undefined`** error when users run `ionic lib update`.