### PR TITLE
fix #1183: run before-hooks with locally installed gulp#4.0

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -228,13 +228,21 @@ Cli.runWithGulp = function runWithGulp(argv, taskInstance, rawCliArguments) {
     log.error(chalk.red('Do you need to run `npm install`?\n'));
     return process.exit(1);
   }
+  
+  // workaround for local gulp version >= 4.0
+  var gulpTasks = gulp.tasks || {};
+  if (gulp['tree'] && gulp.tree().nodes) {
+    gulp.tree().nodes.forEach(function (task) {
+      gulpTasks[task] = true;
+    })
+  }
 
   // setup gulp logging
   Cli.logEvents(gulp, [beforeHook, afterHook]);
 
   // if there is no before hook there's no need to run gulp
   var beforeHookPromise = Q(true);
-  if (gulp.tasks[beforeHook]) {
+  if (gulpTasks[beforeHook]) {
     log.info('\nRunning \'' + beforeHook + '\' gulp task before ' + cmdName);
     beforeHookPromise = Cli.runGulpHook(gulp, beforeHook);
 
@@ -254,7 +262,7 @@ Cli.runWithGulp = function runWithGulp(argv, taskInstance, rawCliArguments) {
 
   // run afterHook
     .then(function() {
-      if (gulp.tasks[afterHook]) {
+      if (gulpTasks[afterHook]) {
         log.info('\nRunning \'' + afterHook + '\' gulp task after ' + cmdName);
 
         return Cli.runGulpHook(gulp, afterHook);
@@ -264,10 +272,16 @@ Cli.runWithGulp = function runWithGulp(argv, taskInstance, rawCliArguments) {
 
 Cli.runGulpHook = function runGulpHook(gulp, hookName) {
 
-  // swallow errors because we already check to make sure the task exists
-  // so not a missingTask error, and gulp already reports its own errors
-  // which we set up with Cli.logEvents
-  return Q.nfcall(gulp.start.bind(gulp), hookName)
+  //run task
+  if (gulp.start) {
+    // swallow errors because we already check to make sure the task exists
+    // so not a missingTask error, and gulp already reports its own errors
+    // which we set up with Cli.logEvents
+    return Q.nfcall(gulp.start.bind(gulp), hookName)
+      .catch(function() {});
+  }
+  // run task with gulp#4.0
+  return Q.nfcall(gulp.parallel([hookName]))
     .catch(function() {});
 };
 


### PR DESCRIPTION
gulp-4.0 changes the way tasks are registered and run internaly, so ionic-cli does not work when you install gulp 4.0. These changes will make before-hooks work again.