### PR TITLE
feat(start): Yarn option to install dependencies

### DIFF
--- a/lib/ionic/start.js
+++ b/lib/ionic/start.js
@@ -30,6 +30,10 @@ var settings = {
       title: 'Skip npm package installation',
       boolean: true
     },
+    '--yarn': {
+      title: 'Use Yarn instead of npm for package installation',
+      boolean: true
+    },
     '--no-cordova|-w': {
       title: 'Create a basic structure without Cordova requirements',
       boolean: true

--- a/spec/tasks/start.spec.js
+++ b/spec/tasks/start.spec.js
@@ -41,6 +41,7 @@ describe('start command', function() {
       expect(start.options['--appname|-a']).toEqual(jasmine.any(String));
       expect(start.options['--id|-i']).toEqual(jasmine.any(String));
       expect(start.options['--skip-npm']).toEqual(jasmine.any(Object));
+      expect(start.options['--yarn']).toEqual(jasmine.any(Object));
       expect(start.options['--no-cordova|-w']).toEqual(jasmine.any(Object));
       expect(start.options['--sass|-s']).toEqual(jasmine.any(Object));
       expect(start.options['--list|-l']).toEqual(jasmine.any(Object));


### PR DESCRIPTION
Add an option to install Node dependencies via yarn instead of npm.

Goes hand-in-hand with driftyco/ionic-app-lib#134