### PR TITLE
fix(#2018) added exit code in build.js file

### DIFF
--- a/lib/ionic/build.js
+++ b/lib/ionic/build.js
@@ -76,6 +76,7 @@ function run(ionic, argv, rawCliArguments) {
     if (ex instanceof Error) {
       log.error(ex);
     }
+    process.exit(1);
   });
 }
 


### PR DESCRIPTION
Added process.exit(1) to build.js catch block.  Fixes issue #2018 