### PR TITLE
Fix live reload on emulator - change emulate ipAddress to publicIp

### DIFF
--- a/packages/cli-plugin-cordova/src/commands/emulate.ts
+++ b/packages/cli-plugin-cordova/src/commands/emulate.ts
@@ -166,7 +166,7 @@ export class EmulateCommand extends Command {
         options: generateBuildOptions(this.metadata, options),
       }))[0];
 
-      await writeConfigXmlContentSrc(this.env.project.directory, `http://${serverSettings.ipAddress}:${serverSettings.httpPort}`);
+      await writeConfigXmlContentSrc(this.env.project.directory, `http://${serverSettings.publicIp}:${serverSettings.httpPort}`);
       tasks.next(`Starting server`);
     }
 


### PR DESCRIPTION
Server settings ipAddress undefined in emulate command, changed to be same as run command.