### PR TITLE
fix(cli): package list doesn’t crash without console

### DIFF
--- a/lib/ionic/package.js
+++ b/lib/ionic/package.js
@@ -180,7 +180,9 @@ function packageList(ionic, argv, dir, project, appId) {
         var count = 0;
         var headers = ['id', 'status', 'platform', 'mode'];
         var table;
-        var screenWidth = process.stdout.getWindowSize()[0];
+        var screenWidth = process.stdout.getWindowSize ?
+          process.stdout.getWindowSize()[0] :
+          80;
 
         if (screenWidth > 100) {
           headers.push('started');


### PR DESCRIPTION
This allows you to process the output of ionic package list with shell
pipes such as:

$ ionic package list | grep SUCCESS

Fixes: #1957