### PR TITLE
fix(generators): do not do lazy load by default

### DIFF
--- a/packages/cli-plugin-ionic-angular/src/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/generate.ts
@@ -25,16 +25,16 @@ export async function generate(args: CLIEventEmitterGenerateEventArgs): Promise<
     case 'page':
       return await AppScripts.processPageRequest(context, name);
     case 'component':
-      const componentData = await promptQuestions('component', context);
+      const componentData = await promptQuestions(context);
       return await AppScripts.processComponentRequest(context, name, componentData);
     case 'directive':
-      const directiveData = await promptQuestions('directive', context);
+      const directiveData = await promptQuestions(context);
       return await AppScripts.processDirectiveRequest(context, name, directiveData);
     case 'pipe':
-      const pipeData = await promptQuestions('pipe', context);
+      const pipeData = await promptQuestions(context);
       return await AppScripts.processPipeRequest(context, name, pipeData);
     case 'provider':
-      const providerData = await promptQuestions('provider', context);
+      const providerData = await promptQuestions(context);
       return await AppScripts.processProviderRequest(context, name, providerData);
     case 'tabs':
       const tabsData = await tabsPromptQuestions();
@@ -44,8 +44,8 @@ export async function generate(args: CLIEventEmitterGenerateEventArgs): Promise<
   return [];
 }
 
-async function promptQuestions(name: string, context: AppScriptsType.BuildContext) {
-  return await prompt(name, context);
+async function promptQuestions(context: AppScriptsType.BuildContext) {
+  return await prompt(context);
 }
 
 async function tabsPromptQuestions() {

--- a/packages/cli-plugin-ionic-angular/src/utils/__tests__/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/utils/__tests__/generate.ts
@@ -16,49 +16,8 @@ describe('prompt', () => {
       appNgModulePath: '/path/to/nowhere'
     };
 
-    const result = await generate.prompt('pipe', context);
+    const result = await generate.prompt(context);
     expect(result).toEqual(context.appNgModulePath);
-  });
-
-  it('should return a file path to a specific ngModule', async () => {
-    jest.resetModules();
-    jest.mock('@ionic/cli-utils', () => ({
-      load: jest.fn((modulePath) => {
-        switch (modulePath) {
-          case 'inquirer':
-            return {
-              prompt: jest.fn().mockReturnValueOnce({
-                usage: false
-              }).mockReturnValueOnce({
-                prettyName: '/path/to/ngModule',
-                whereUsed: '../../../../../../../../../path/to'
-              });
-            };
-          case '@ionic/app-scripts':
-            return {
-              getNgModules: jest.fn().mockReturnValueOnce([
-                {
-                  relativePath: '/path/to/ngModule',
-                  absolutePath: '/path/to/ngModule'
-                },
-                {
-                  relativePath: '/path/to/ngModule',
-                  absolutePath: '/path/to/ngModule'
-                }
-              ]),
-              getStringPropertyValue: jest.fn().mockReturnValueOnce('.module.ts')
-            };
-        }
-      })
-    }));
-
-    const generate = require('../generate');
-
-    // mock context
-    const context = { rootDir: 'my/cool/rootDir' };
-
-    const result = await generate.prompt('pipe', context);
-    expect(result).toEqual('/path/to/ngModule');
   });
 
 });
@@ -75,7 +34,7 @@ describe('tabsPrompt', () => {
           tabName: 'CoolTabOne'
         }).mockReturnValueOnce({
           tabName: 'CoolTabTwo'
-        });
+        })
       })
     }));
 

--- a/packages/cli-plugin-ionic-angular/src/utils/generate.ts
+++ b/packages/cli-plugin-ionic-angular/src/utils/generate.ts
@@ -17,41 +17,8 @@ export async function getPages(context: AppScriptsType.BuildContext) {
   });
 }
 
-export async function prompt(type: string, context: AppScriptsType.BuildContext) {
-  const inquirer = load('inquirer');
-  const usageQuestion = await inquirer.prompt({
-    type: 'confirm',
-    name: 'usage',
-    message: `Use this ${type} in more than one template?`
-  });
-
-  if (!usageQuestion.usage) {
-    const fileChoices = await getPages(context);
-
-    const filteredChoices = fileChoices.map((file) => {
-      return {
-        prettyName: path.dirname(file.relativePath),
-        fullName: file.relativePath
-      };
-    });
-
-    const usagePlaces = await inquirer.prompt({
-      type: 'list',
-      name: 'whereUsed',
-      message: `Page or component that will be using this ${type}`,
-      choices: filteredChoices.map((choiceObject) => {
-        return choiceObject.prettyName;
-      })
-    });
-
-    const chosenPath = fileChoices.find((file): boolean => {
-      return path.dirname(file.relativePath) === usagePlaces.whereUsed;
-    });
-
-    return chosenPath.absolutePath;
-  } else {
-    return context.appNgModulePath;
-  }
+export async function prompt(context: AppScriptsType.BuildContext) {
+  return context.appNgModulePath;
 }
 
 export async function tabsPrompt() {


### PR DESCRIPTION
We currently do not want generators to be set up for lazy loading by default. With no lazy loading the user should not be prompted about where they would like their `<insert component type here>` put as it should always go in the "root" ngModule.