### PR TITLE
Fix ReadMe Link to Ionic Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ you have questions or issues please feel free to open a new issue.
 * [tabs](https://github.com/driftyco/ionic2-starter-tabs)
 * [sidemenu](https://github.com/driftyco/ionic2-starter-sidemenu)
 * [conference](https://github.com/driftyco/ionic-conference-app)
-* [tutorial](https://github.com/driftyco/ionis2-starter-tutorial)
+* [tutorial](https://github.com/driftyco/ionic2-starter-tutorial)
 
 ## Service Proxies
 


### PR DESCRIPTION
Ionic 2 Tutorial template currently links to https://github.com/driftyco/ionis2-starter-tutorial and not https://github.com/driftyco/ionic2-starter-tutorial (notice the **s** and not **c** on ionic) causing a 404 on