### PR TITLE
Pass chosen ip from list back to options

### DIFF
--- a/packages/cli-plugin-ionic-angular/src/serve.ts
+++ b/packages/cli-plugin-ionic-angular/src/serve.ts
@@ -32,6 +32,7 @@ export async function serve(args: CommandHookArgs): Promise<{ [key: string]: any
           choices: availableIPs.map(ip => ip.address)
         });
         chosenIP = promptAnswers['ip'];
+        args.options.address = chosenIP;
       }
     }
   }


### PR DESCRIPTION
This enables use of the chosen address from the app-scripts

Fixes #2082