### PR TITLE
fix(readme): remove extra @latest in npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ issues on GitHub should be reserved for bug reports and feature requests.
 ## Install
 
 ```bash
-$ npm install -g ionic@latest
+$ npm install -g ionic
 ```
 
 :memo: *Note: For a global install of `-g ionic`, OSX/Linux users may need to prefix


### PR DESCRIPTION
Makes the npm installer install the stable build instead of being on the @latest branch