### PR TITLE
add httpPort to ionic1 plugin options

### DIFF
--- a/packages/cli-plugin-ionic1/src/serve/config.ts
+++ b/packages/cli-plugin-ionic1/src/serve/config.ts
@@ -1,24 +1,25 @@
 import * as path from 'path';
 
 export interface ServerOptions {
- projectRoot: string;
- wwwDir: string;
- address: string;
- port: number;
- livereloadPort: number;
- browser: string | undefined;
- browseroption: string | undefined;
- platform: string | undefined;
- consolelogs: boolean;
- serverlogs: boolean;
- nobrowser: boolean;
- nolivereload: boolean;
- noproxy: boolean;
- lab: boolean;
- iscordovaserve: boolean;
- nogulp: boolean;
- nosass: boolean;
- gulpInstalled: boolean;
+  projectRoot: string;
+  wwwDir: string;
+  address: string;
+  port: number;
+  httpPort: number;
+  livereloadPort: number;
+  browser: string | undefined;
+  browseroption: string | undefined;
+  platform: string | undefined;
+  consolelogs: boolean;
+  serverlogs: boolean;
+  nobrowser: boolean;
+  nolivereload: boolean;
+  noproxy: boolean;
+  lab: boolean;
+  iscordovaserve: boolean;
+  nogulp: boolean;
+  nosass: boolean;
+  gulpInstalled: boolean;
 }
 
 export const WATCH_PATTERNS = [

--- a/packages/cli-plugin-ionic1/src/serve/index.ts
+++ b/packages/cli-plugin-ionic1/src/serve/index.ts
@@ -51,6 +51,7 @@ export async function serve(args: CommandHookArgs): Promise<{ [key: string]: any
     wwwDir: path.join(args.env.project.directory, 'www'),
     address: <string>args.options['address'] || DEFAULT_ADDRESS,
     port: stringToInt(<string>args.options['port'], DEFAULT_SERVER_PORT),
+    httpPort: stringToInt(<string>args.options['port'], DEFAULT_SERVER_PORT),
     livereloadPort: stringToInt(<string>args.options['livereload-port'], DEFAULT_LIVERELOAD_PORT),
     browser: <string>args.options['browser'],
     browseroption: <string>args.options['browseroption'],
@@ -73,7 +74,7 @@ export async function serve(args: CommandHookArgs): Promise<{ [key: string]: any
     findClosestOpenPort(serverOptions.address, serverOptions.port),
     findClosestOpenPort(serverOptions.address, serverOptions.livereloadPort),
   ]);
-  serverOptions.port = portResults[0];
+  serverOptions.port = serverOptions.httpPort = portResults[0];
   serverOptions.livereloadPort = portResults[1];
 
   // Check if gulp is installed globally for sass


### PR DESCRIPTION
For compatibility with the CLI, which expects this property.

Addresses https://github.com/driftyco/ionic-cli/issues/2274.